### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ route('social.redirect', ['provider' => 'facebook']);
 route('social.redirect', ['provider' => 'twitter']);
 ```
 
-###Todo's
+### Todo's
 Project is not over, I will publish few more tutorials regarding this matter. You can expect:
   - ~~Handling when user disallows social app access~~
   - Taking emails of users who sign-up over Twitter and other providers which don't share that data


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
